### PR TITLE
Issue #516 - Cleaned up fix

### DIFF
--- a/public/create/scripts/app_controller.js
+++ b/public/create/scripts/app_controller.js
@@ -97,7 +97,6 @@ app.controller('appController', [ '$http', '$scope', 'userService', '$rootScope'
 				.success( function( data ) {
 					$http.post('/user/login/', angular.toJson( user ) )
 						.success( function( data ) {
-							$scope.user.password = null; // No need to store user password anymore.
 							next();
 						});
 				})
@@ -216,6 +215,9 @@ app.service('userService', function( $rootScope, $http ) {
 	return {
 		setUser: function( user ) {
 			this.user = user;
+			if (user.password) {
+				delete user.password; // No need to store user password hash.
+			}
 			$rootScope.$emit('user:updated', this.user);
 		},
 		getUser: function() {
@@ -225,7 +227,6 @@ app.service('userService', function( $rootScope, $http ) {
 			var self = this;
 			$http.put( '/user', angular.toJson( user ) )
 				.success( function( data ) {
-					data.user.password = null; // No need to store user password anymore.
 					self.setUser( data.user );
 					if (next) {
 						next();

--- a/public/create/scripts/projectSpace_controller.js
+++ b/public/create/scripts/projectSpace_controller.js
@@ -24,13 +24,12 @@ function projectSpaceController($scope, $http, projectsService, userService, $q,
 			user.password = $scope.newPassword;
 			user.passwordOld = $scope.password;
 			$http.put( '/user', angular.toJson( user ) )
-			.success( function( data ) {
-				$scope.editPassword = !$scope.editPassword;
-				$scope.user.password = null; // No need to store user password anymore.
-			})
-			.error( function( data ) {
-				$scope.editPasswordForm.currentPassword.$invalid = true;
-			});
+				.success( function( data ) {
+					$scope.editPassword = !$scope.editPassword;
+				})
+				.error( function( data ) {
+					$scope.editPasswordForm.currentPassword.$invalid = true;
+				});
 		}
 	}
 


### PR DESCRIPTION
@mortengf Sorry i did some minor cleanup up to my changes. 
I realized the actual bug before was that after changing the password the user was forced to press "Save Settings" which would then send a user.update request with the full frontend version of the user-model - including the _hashed_ password. This would result in the backend changing the password to be the hashed password (we stored the _hash of the hashed password_ in the database). So the actual fix is that we don't remember the password hash in the frontend user model anymore - and thereby we don't accidentially send to the backend as a new password.

My cleanup in the pull request is just that i moved the removal of this hashed password from the user model to a local place (userService.setUser) instead of doing it in various places. I hope it's okay.
