### PR TITLE
Fixes issue #467 and #466

### DIFF
--- a/routes/user.js
+++ b/routes/user.js
@@ -445,12 +445,9 @@ exports.sso = function (req, res, next) {
 		if (sso.validate(payload, sig)) {
 			var nonce = sso.getNonce(payload);
 			var userparams = {
-				// Required, will throw exception otherwise
 				"nonce":       nonce,
-				"external_id": req.user._id,
+				"external_id": req.user.id,
 				"email":       req.user.email,
-				// Optional
-				//"username": req.user.username,
 				"name":        req.user.firstname + " " + req.user.lastname
 			};
 			var q = sso.buildLoginString(userparams);


### PR DESCRIPTION
@mortengf Review please.

It turned out we didn't send a proper external-id to discourse, so it ignored it, and grouped all users together as one.

We erroneously send the ObjectId object instead of string representation along. To fix this i used the magic Mongoose property "id":
http://mongoosejs.com/docs/guide.html#id
I would also work with `toHexString()`, casting or `toString()" - but this seems nice :)
