### PR TITLE
set minimum width of registration text

### DIFF
--- a/public/create/pages/css/shared/default.css
+++ b/public/create/pages/css/shared/default.css
@@ -245,6 +245,7 @@ textarea {
 .registration-text {
 	font-weight: 700;
 	margin: 0 0 10px 0;
+	min-width: 310px;
 }
 @media all and (min-width: 1220px) {
 	.registration-text {


### PR DESCRIPTION
to not make the input fields jump around when the text on the left is
smaller in some cases
